### PR TITLE
remove_Uglifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  #config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
UglifierというJavaScriptを軽量化するためのgemをコメントアウトする。


# Why
ChatSpaceのJavaScriptで使用しているテンプレートリテラル記法（`）に対応していないため。
デプロイ時にエラーを防ぐため。

