### PR TITLE
本番環境のmysqlの設定に合わせるため

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,7 @@ test:
 production:
   <<: *default
   database: chat-space_production
-  username: chat-space
-  password: <%= ENV['CHAT-SPACE_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock
+


### PR DESCRIPTION
# What
database.ymlのコード編集。
mysqlと整合性をもたせるため

# Why
unicornをEC2側で立ち上げようとすると、

```
E, [2020-04-07T03:51:42.012820 #5482] ERROR -- : Can't connect to local MySQL server through socket 
'/tmp/mysql.sock' (2) (Mysql2::Error::ConnectionError)
```
この様なエラーがターミナル上に確認できたが、このエラーを解決するため。
エラーの内容は、本番環境でインストールするmysqlの設定がローカルとは異なるというものだっため、整合性を持たせる様にする必要があったため。

